### PR TITLE
Add Secret Deletion Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ The number of allowed concurrent calls to the set secret endpoint. Lower this nu
 
 Run everything except for secret create and update functionality.
 
+### `delete`
+
+When set to `true`, the action will find and delete the selected secrets from repositories. Defaults to `false`.
+
 ## Usage
 
 ```yaml

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -32,6 +32,7 @@ describe("getConfig", () => {
   const DRY_RUN = false;
   const RETRIES = 3;
   const CONCURRENCY = 50;
+  const RUN_DELETE = false;
 
   const inputs = {
     INPUT_GITHUB_TOKEN: GITHUB_TOKEN,
@@ -40,7 +41,8 @@ describe("getConfig", () => {
     INPUT_REPOSITORIES_LIST_REGEX: String(REPOSITORIES_LIST_REGEX),
     INPUT_DRY_RUN: String(DRY_RUN),
     INPUT_RETRIES: String(RETRIES),
-    INPUT_CONCURRENCY: String(CONCURRENCY)
+    INPUT_CONCURRENCY: String(CONCURRENCY),
+    INPUT_RUN_DELETE: String(RUN_DELETE)
   };
 
   beforeEach(() => {
@@ -65,7 +67,8 @@ describe("getConfig", () => {
       REPOSITORIES_LIST_REGEX,
       DRY_RUN,
       RETRIES,
-      CONCURRENCY
+      CONCURRENCY,
+      RUN_DELETE
     });
   });
 
@@ -85,7 +88,7 @@ describe("getConfig", () => {
       ["", false]
     ];
 
-    for (let [value, expected] of cases) {
+    for (const [value, expected] of cases) {
       process.env["INPUT_DRY_RUN"] = value;
       const actual = getConfig().DRY_RUN;
       expect(`${value}=${actual}`).toEqual(`${value}=${expected}`);

--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -21,7 +21,8 @@ import {
   filterReposByPatterns,
   listAllMatchingRepos,
   publicKeyCache,
-  setSecretForRepo
+  setSecretForRepo,
+  deleteSecretForRepo
 } from "../src/github";
 
 // @ts-ignore-next-line
@@ -134,6 +135,32 @@ describe("setSecretForRepo", () => {
 
   test("setSecretForRepo should should call set secret endpoint", async () => {
     await setSecretForRepo(octokit, "FOO", secrets.FOO, repo, false);
+    expect(nock.isDone()).toBeTruthy();
+  });
+});
+
+describe("deleteSecretForRepo", () => {
+  const repo = fixture[0].response;
+
+  jest.setTimeout(30000);
+
+  const secrets = { FOO: "BAR" };
+  let deleteSecretMock: nock.Scope;
+
+  beforeEach(() => {
+    nock.cleanAll();
+    deleteSecretMock = nock("https://api.github.com")
+      .delete(`/repos/${repo.full_name}/actions/secrets/FOO`)
+      .reply(200);
+  });
+
+  test("deleteSecretForRepo should not delete secret with dry run", async () => {
+    await deleteSecretForRepo(octokit, "FOO", secrets.FOO, repo, true);
+    expect(deleteSecretMock.isDone()).toBeFalsy();
+  });
+
+  test("deleteSecretForRepo should call set secret endpoint", async () => {
+    await deleteSecretForRepo(octokit, "FOO", secrets.FOO, repo, false);
     expect(nock.isDone()).toBeTruthy();
   });
 });

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -84,3 +84,23 @@ test("run should succeed with a repo and secret with repository_list_regex as fa
 
   expect(process.exitCode).toBe(undefined);
 });
+
+test("run should succeed with delete enabled, a repo and secret with repository_list_regex as false", async () => {
+  (github.deleteSecretForRepo as jest.Mock) = jest
+    .fn()
+    .mockImplementation(async () => null);
+
+  (config.getConfig as jest.Mock) = jest.fn().mockReturnValue({
+    GITHUB_TOKEN: "token",
+    SECRETS: ["BAZ"],
+    REPOSITORIES: [fixture[0].response.full_name],
+    REPOSITORIES_LIST_REGEX: false,
+    DRY_RUN: false,
+    RUN_DELETE: true,
+    CONCURRENCY: 1
+  });
+  await run();
+
+  expect(github.deleteSecretForRepo as jest.Mock).toBeCalledTimes(1);
+  expect(process.exitCode).toBe(undefined);
+});

--- a/__tests__/secrets.test.ts
+++ b/__tests__/secrets.test.ts
@@ -18,7 +18,7 @@ import * as core from "@actions/core";
 
 import { getSecrets } from "../src/secrets";
 
-let setSecretMock: jest.Mock = jest.fn();
+const setSecretMock: jest.Mock = jest.fn();
 
 beforeAll(() => {
   // @ts-ignore-next-line

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,11 @@ inputs:
       number to avoid abuse limits.
     default: "10"
     required: false
+  delete:
+    description: |
+      When set to `true`, the action will find and delete the selected secrets from repositories. Defaults to `false`.
+    default: false
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ export interface Config {
   DRY_RUN: boolean;
   RETRIES: number;
   CONCURRENCY: number;
+  RUN_DELETE: boolean;
 }
 
 export function getConfig(): Config {
@@ -40,6 +41,9 @@ export function getConfig(): Config {
     ),
     DRY_RUN: ["1", "true"].includes(
       core.getInput("DRY_RUN", { required: false }).toLowerCase()
+    ),
+    RUN_DELETE: ["1", "true"].includes(
+      core.getInput("DELETE", { required: false }).toLowerCase()
     )
   };
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -184,3 +184,23 @@ export async function setSecretForRepo(
     });
   }
 }
+
+export async function deleteSecretForRepo(
+  octokit: any,
+  name: string,
+  secret: string,
+  repo: Repository,
+  dry_run: boolean
+): Promise<void> {
+  core.info(`Remove ${name} from ${repo.full_name}`);
+
+  try {
+    if (!dry_run) {
+      const action = "DELETE";
+      const request = `/repos/${repo.full_name}/actions/secrets/${name}`;
+      return octokit.request(`${action} ${request}`);
+    }
+  } catch (HttpError) {
+    //If secret is not found in target repo, silently continue
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,6 @@ export async function run(): Promise<void> {
 
     const limit = pLimit(config.CONCURRENCY);
     const calls: Promise<void>[] = [];
-    try {
       for (const repo of repos) {
         for (const k of Object.keys(secrets)) {
           const action = config.RUN_DELETE
@@ -98,9 +97,6 @@ export async function run(): Promise<void> {
         }
       }
       await Promise.all(calls);
-    } catch (HttpError) {
-      //If secret is not found in target repo, silently continue
-    }
   } catch (error) {
     /* istanbul ignore next */
     core.error(error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,18 +85,18 @@ export async function run(): Promise<void> {
 
     const limit = pLimit(config.CONCURRENCY);
     const calls: Promise<void>[] = [];
-      for (const repo of repos) {
-        for (const k of Object.keys(secrets)) {
-          const action = config.RUN_DELETE
-            ? deleteSecretForRepo
-            : setSecretForRepo;
+    for (const repo of repos) {
+      for (const k of Object.keys(secrets)) {
+        const action = config.RUN_DELETE
+          ? deleteSecretForRepo
+          : setSecretForRepo;
 
-          calls.push(
-            limit(() => action(octokit, k, secrets[k], repo, config.DRY_RUN))
-          );
-        }
+        calls.push(
+          limit(() => action(octokit, k, secrets[k], repo, config.DRY_RUN))
+        );
       }
-      await Promise.all(calls);
+    }
+    await Promise.all(calls);
   } catch (error) {
     /* istanbul ignore next */
     core.error(error);


### PR DESCRIPTION
Allow users to delete secrets from repositories using the same means as adding them by setting the optional input "delete" to true.
Secret deletion was exposed through the GitHub API but not added to octokit so deletion is done by using Octokit.Request() to make an API call. In addition to the new unit tests method, I tested this thoroughly on my own repositories. 