### PR TITLE
chore(action): update from Node12 to Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,5 +63,5 @@ inputs:
       environment with the name of this value.
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
🚨 Node 12 has an end of life on April 30, 2022.

The GitHub Actions workflow gives the following annotation while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12.  And resolves Action Gives Deprecation Warning issue #81.

This is supported on all Actions Runners v2.285.0 or later.

- Also we can consider to update core and node setup dependencies like #79 in the future.
	- You can see more here: https://github.com/actions/setup-node/compare/v2.5.1...v3.0.0


Signed-off-by: Enes <ahmedenesturan@gmail.com>